### PR TITLE
Get drawing controls from URL

### DIFF
--- a/templates/drawing_controls.html
+++ b/templates/drawing_controls.html
@@ -1,9 +1,14 @@
-<link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
-<link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/dataTables.bootstrap4.min.css">
-<link rel="stylesheet" href="https://cdn.datatables.net/select/1.3.1/css/select.dataTables.min.css">
+<link rel="stylesheet"
+      href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
+<link rel="stylesheet"
+      href="https://cdn.datatables.net/1.10.20/css/dataTables.bootstrap4.min.css">
+<link rel="stylesheet"
+      href="https://cdn.datatables.net/select/1.3.1/css/select.dataTables.min.css">
 <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/select/1.3.1/js/dataTables.select.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js">
+</script>
+<script src="https://cdn.datatables.net/select/1.3.1/js/dataTables.select.min.js">
+</script>
 <script>
 $(document).ready(function() {
     $('.table').DataTable({
@@ -19,9 +24,12 @@ $(document).ready(function() {
         order: [[ 1, 'asc' ]]
     });
 
-    let annotations = ((annotations));
-    for (let table_i = 0; table_i < document.getElementsByClassName("table").length; table_i++) {
-        $("#peaks_" + table_i).DataTable().rows(annotations[table_i]).select();
+    // Select annotated peaks in the data table.
+    let annotations = (( annotations ));
+    for (let table_i = 0;
+            table_i < document.getElementsByClassName('table').length;
+            table_i++) {
+        $('#peaks_' + table_i).DataTable().rows(annotations[table_i]).select();
     }
 
     // Set initial drawing parameters.
@@ -30,8 +38,8 @@ $(document).ready(function() {
 </script>
 
 (% set draw_parameters = {
-    'width': plotting_args['width'] | default(10, true),
-    'height': plotting_args['height'] | default(6, true),
+    'width': plotting_args['width'] | default(10.0, true),
+    'height': plotting_args['height'] | default(6.0, true),
     'mz_min': plotting_args['mz_min'] | default(none, true),
     'mz_max': plotting_args['mz_max'] | default(none, true),
     'max_intensity': (plotting_args['max_intensity'] * 100 |
@@ -51,58 +59,82 @@ $(document).ready(function() {
         <h3 class="text-center">Drawing Controls</h3>
         <hr>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Figure size</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Figure size
+            </div>
             <div class="col-8 input-group">
-                <input type="number" id="width" class="form-control" min="1" max="20" value="((draw_parameters['width']))" step="any">
+                <input type="number" id="width" class="form-control"
+                       min="1" max="20" value="(( draw_parameters['width'] ))"
+                       step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
                 <span class="col-form-label">&nbsp;X&nbsp;</span>
-                <input type="number" id="height" class="form-control" min="1" max="20" value="((draw_parameters['height']))" step="any">
+                <input type="number" id="height" class="form-control"
+                       min="1" max="20" value="(( draw_parameters['height'] ))"
+                       step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Mass range</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Mass range
+            </div>
             <div class="col-8 input-group">
-                <input type="number" id="mz_min" class="form-control" min="0" value="((draw_parameters['mz_min']))" step="any">
+                <input type="number" id="mz_min" class="form-control"
+                       min="0" value="(( draw_parameters['mz_min'] ))"
+                       step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
                 <span class="col-form-label">&nbsp;&ndash;&nbsp;</span>
-                <input type="number" id="mz_max" class="form-control" min="0" value="((draw_parameters['mz_max']))" step="any">
+                <input type="number" id="mz_max" class="form-control"
+                       min="0" value="(( draw_parameters['mz_max'] ))"
+                       step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Intensity range</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Intensity range
+            </div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Maximum intensity:&nbsp;</span>
-                <input type="number" id="max_intensity" class="form-control" min="0" max="200" value="((draw_parameters['max_intensity']))" step="1">
+                <input type="number" id="max_intensity" class="form-control"
+                       min="0" max="200"
+                       value="(( draw_parameters['max_intensity'] ))" step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&percnt;</span>
                 </div>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Grid</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Grid
+            </div>
             <div class="col-8">
                 <div class="form-check">
-                    <input type="checkbox" class="form-check-input" id="grid" (("checked" if draw_parameters['grid'] else ""))>
-                    <label class="form-check-label col-form-label" for="grid">&nbsp;Display grid</label>
+                    <input type="checkbox" class="form-check-input" id="grid"
+                           (( "checked" if draw_parameters['grid'] ))>
+                    <label class="form-check-label col-form-label" for="grid">
+                        &nbsp;Display grid
+                    </label>
                 </div>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Peak labeling</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Peak labeling
+            </div>
             <div class="col-8">
                 (% for spectrum in peaks %)
                     (% set spectrum_loop = loop %)
-                    <table id="peaks_((spectrum_loop.index - 1))" class="table">
+                    <table class="table"
+                           id="peaks_(( spectrum_loop.index - 1 ))">
                         <thead>
                             <tr class="align-self-center">
                                 <th></th>
@@ -114,8 +146,12 @@ $(document).ready(function() {
                             (% for peak in spectrum %)
                                 <tr>
                                     <td></td>
-                                    <td class="text-right">(( '{:.4f}'.format(peak[0]) ))</td>
-                                    <td class="text-right">(( '{:.0%}'.format(peak[1]) ))</td>
+                                    <td class="text-right">
+                                        (( '{:.4f}'.format(peak[0]) ))
+                                    </td>
+                                    <td class="text-right">
+                                        (( '{:.0%}'.format(peak[1]) ))
+                                    </td>
                                 </tr>
                             (% endfor %)
                         </tbody>
@@ -124,35 +160,61 @@ $(document).ready(function() {
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Label precision</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Label precision
+            </div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Decimal places:&nbsp;</span>
-                <input type="number" id="annotate_precision" class="form-control" min="0" max="10" value="((draw_parameters['annotate_precision']))" step="1">
+                <input type="number" id="annotate_precision"
+                       class="form-control" min="0" max="10"
+                       value="(( draw_parameters['annotate_precision'] ))"
+                       step="1">
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Label rotation</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Label rotation
+            </div>
             <div class="col-8 input-group">
-                <input type="number" id="annotation_rotation" class="form-control" min="0" max="90" value="((draw_parameters['annotation_rotation']))" step="1">
+                <input type="number" id="annotation_rotation"
+                       class="form-control" min="0" max="90"
+                       value="(( draw_parameters['annotation_rotation'] ))"
+                       step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&deg;</span>
                 </div>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Cosine</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Cosine
+            </div>
             <div class="col-8 input-group">
                 <select class="form-control custom-select" id="cosine">
-                    <option value="standard" (("selected" if draw_parameters['cosine'] == 'standard'))>Standard</option>
-                    <option value="shifted" (("selected" if draw_parameters['cosine'] == 'shifted'))>Shifted</option>
-                    <option value="off" (("selected" if draw_parameters['cosine'] == false))>Off</option>
+                    <option value="standard"
+                            (( "selected" if draw_parameters['cosine'] == 'standard' ))>
+                        Standard
+                    </option>
+                    <option value="shifted"
+                            (( "selected" if draw_parameters['cosine'] == 'shifted' ))>
+                        Shifted
+                    </option>
+                    <option value="off"
+                            (( "selected" if draw_parameters['cosine'] == false ))>
+                        Off
+                    </option>
                 </select>
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-4 col-form-label font-weight-bold text-right">Fragment tolerance</div>
+            <div class="col-4 col-form-label font-weight-bold text-right">
+                Fragment tolerance
+            </div>
             <div class="col-8 input-group">
-                <input type="number" id="fragment_mz_tolerance" class="form-control" min="0.01" max="1" value="((draw_parameters['fragment_mz_tolerance']))" step="0.01">
+                <input type="number" id="fragment_mz_tolerance"
+                       class="form-control" min="0.01" max="1"
+                       value="(( draw_parameters['fragment_mz_tolerance'] ))"
+                       step="0.01">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
@@ -160,7 +222,9 @@ $(document).ready(function() {
         </div>
         <div class="form-group row">
             <div class="col-2 offset-5">
-                <button class="btn btn-primary" onclick=updateFigure()>Update Figure</button>
+                <button class="btn btn-primary" onclick=updateFigure()>
+                    Update Figure
+                </button>
             </div>
         </div>
     </div>
@@ -169,9 +233,12 @@ $(document).ready(function() {
 <script type="text/javascript">
     function getDrawingControls() {
         let annotate_peaks = [];
-        for (let table_i = 0; table_i < document.getElementsByClassName("table").length; table_i++) {
+        for (let table_i = 0;
+                table_i < document.getElementsByClassName('table').length;
+                table_i++) {
             let selected_peaks = [];
-            let table_peaks = $("#peaks_" + table_i).DataTable().rows({selected: true}).data();
+            let table_peaks = ($('#peaks_' + table_i).DataTable()
+                               .rows({selected: true}).data());
             for (let i = 0; i < table_peaks.length; i++) {
                 selected_peaks.push(parseFloat(table_peaks[i][1]));
             }

--- a/templates/drawing_controls.html
+++ b/templates/drawing_controls.html
@@ -221,9 +221,12 @@ $(document).ready(function() {
             </div>
         </div>
         <div class="form-group row">
-            <div class="col-2 offset-5">
+            <div class="offset-4">
                 <button class="btn btn-primary" onclick=updateFigure()>
                     Update Figure
+                </button>
+                <button class="btn btn-secondary" onclick=resetFigure()>
+                    Reset Figure
                 </button>
             </div>
         </div>

--- a/templates/drawing_controls.html
+++ b/templates/drawing_controls.html
@@ -23,6 +23,9 @@ $(document).ready(function() {
     for (let table_i = 0; table_i < document.getElementsByClassName("table").length; table_i++) {
         $("#peaks_" + table_i).DataTable().rows(annotations[table_i]).select();
     }
+
+    // Set initial drawing parameters.
+    updateFigure();
 } );
 </script>
 

--- a/templates/drawing_controls.html
+++ b/templates/drawing_controls.html
@@ -26,6 +26,23 @@ $(document).ready(function() {
 } );
 </script>
 
+(% set draw_parameters = {
+    'width': plotting_args['width'] | default(10, true),
+    'height': plotting_args['height'] | default(6, true),
+    'mz_min': plotting_args['mz_min'] | default(none, true),
+    'mz_max': plotting_args['mz_max'] | default(none, true),
+    'max_intensity': (plotting_args['max_intensity'] * 100 |
+                      default(none, true)),
+    'grid': plotting_args['grid'] == true,
+    'annotate_precision': (plotting_args['annotate_precision'] |
+                           default(4, true)),
+    'annotation_rotation': (plotting_args['annotation_rotation'] |
+                            default(90, true)),
+    'cosine': plotting_args['cosine'],
+    'fragment_mz_tolerance': (plotting_args['fragment_mz_tolerance'] |
+                              default(0.02, true))
+} %)
+
 <div class="row">
     <div class="col-6 offset-3">
         <h3 class="text-center">Drawing Controls</h3>
@@ -33,12 +50,12 @@ $(document).ready(function() {
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Figure size</div>
             <div class="col-8 input-group">
-                <input type="number" id="width" class="form-control" min="1" max="20" value="((plotting_args['width']|default(10, true)))" step="any">
+                <input type="number" id="width" class="form-control" min="1" max="20" value="((draw_parameters['width']))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
                 <span class="col-form-label">&nbsp;X&nbsp;</span>
-                <input type="number" id="height" class="form-control" min="1" max="20" value="((plotting_args['height']|default(6, true)))" step="any">
+                <input type="number" id="height" class="form-control" min="1" max="20" value="((draw_parameters['height']))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
@@ -47,12 +64,12 @@ $(document).ready(function() {
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Mass range</div>
             <div class="col-8 input-group">
-                <input type="number" id="mz_min" class="form-control" min="0" value="((plotting_args['mz_min']|default(none, true)))" step="any">
+                <input type="number" id="mz_min" class="form-control" min="0" value="((draw_parameters['mz_min']))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
                 <span class="col-form-label">&nbsp;&ndash;&nbsp;</span>
-                <input type="number" id="mz_max" class="form-control" min="0" value="((plotting_args['mz_max']|default(none, true)))" step="any">
+                <input type="number" id="mz_max" class="form-control" min="0" value="((draw_parameters['mz_max']))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
@@ -62,7 +79,7 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Intensity range</div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Maximum intensity:&nbsp;</span>
-                <input type="number" id="max_intensity" class="form-control" min="0" max="200" value="((plotting_args['max_intensity'] * 100|default(none, true)))" step="1">
+                <input type="number" id="max_intensity" class="form-control" min="0" max="200" value="((draw_parameters['max_intensity']))" step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&percnt;</span>
                 </div>
@@ -72,7 +89,7 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Grid</div>
             <div class="col-8">
                 <div class="form-check">
-                    <input type="checkbox" class="form-check-input" id="grid" (("checked" if plotting_args["grid"] == true else ""))>
+                    <input type="checkbox" class="form-check-input" id="grid" (("checked" if draw_parameters['grid'] else ""))>
                     <label class="form-check-label col-form-label" for="grid">&nbsp;Display grid</label>
                 </div>
             </div>
@@ -107,13 +124,13 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Label precision</div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Decimal places:&nbsp;</span>
-                <input type="number" id="annotate_precision" class="form-control" min="0" max="10" value="((plotting_args['annotate_precision']|default(4, true)))" step="1">
+                <input type="number" id="annotate_precision" class="form-control" min="0" max="10" value="((draw_parameters['annotate_precision']))" step="1">
             </div>
         </div>
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Label rotation</div>
             <div class="col-8 input-group">
-                <input type="number" id="annotation_rotation" class="form-control" min="0" max="90" value="((plotting_args['annotation_rotation']|default(90, true)))" step="1">
+                <input type="number" id="annotation_rotation" class="form-control" min="0" max="90" value="((draw_parameters['annotation_rotation']))" step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&deg;</span>
                 </div>
@@ -123,16 +140,16 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Cosine</div>
             <div class="col-8 input-group">
                 <select class="form-control custom-select" id="cosine">
-                    <option value="standard" (("selected" if plotting_args["cosine"] == "standard"))>Standard</option>
-                    <option value="shifted" (("selected" if plotting_args["cosine"] == "shifted"))>Shifted</option>
-                    <option value="off" (("selected" if plotting_args["cosine"] == false))>Off</option>
+                    <option value="standard" (("selected" if draw_parameters['cosine'] == 'standard'))>Standard</option>
+                    <option value="shifted" (("selected" if draw_parameters['cosine'] == 'shifted'))>Shifted</option>
+                    <option value="off" (("selected" if draw_parameters['cosine'] == false))>Off</option>
                 </select>
             </div>
         </div>
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Fragment tolerance</div>
             <div class="col-8 input-group">
-                <input type="number" id="fragment_mz_tolerance" class="form-control" min="0.01" max="1" value="((plotting_args['fragment_mz_tolerance']|default(0.02, true)))" step="0.01">
+                <input type="number" id="fragment_mz_tolerance" class="form-control" min="0.01" max="1" value="((draw_parameters['fragment_mz_tolerance']))" step="0.01">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>

--- a/templates/drawing_controls.html
+++ b/templates/drawing_controls.html
@@ -33,12 +33,12 @@ $(document).ready(function() {
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Figure size</div>
             <div class="col-8 input-group">
-                <input type="number" id="width" class="form-control" min="1" max="20" value="10" step="any">
+                <input type="number" id="width" class="form-control" min="1" max="20" value="((plotting_args['width']|default(10, true)))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
                 <span class="col-form-label">&nbsp;X&nbsp;</span>
-                <input type="number" id="height" class="form-control" min="1" max="20" value="6" step="any">
+                <input type="number" id="height" class="form-control" min="1" max="20" value="((plotting_args['height']|default(6, true)))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text">"</span>
                 </div>
@@ -47,12 +47,12 @@ $(document).ready(function() {
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Mass range</div>
             <div class="col-8 input-group">
-                <input type="number" id="mz_min" class="form-control" min="0" step="any">
+                <input type="number" id="mz_min" class="form-control" min="0" value="((plotting_args['mz_min']|default(none, true)))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
                 <span class="col-form-label">&nbsp;&ndash;&nbsp;</span>
-                <input type="number" id="mz_max" class="form-control" min="0" step="any">
+                <input type="number" id="mz_max" class="form-control" min="0" value="((plotting_args['mz_max']|default(none, true)))" step="any">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>
@@ -62,7 +62,7 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Intensity range</div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Maximum intensity:&nbsp;</span>
-                <input type="number" id="max_intensity" class="form-control" min="0" max="200" step="1">
+                <input type="number" id="max_intensity" class="form-control" min="0" max="200" value="((plotting_args['max_intensity'] * 100|default(none, true)))" step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&percnt;</span>
                 </div>
@@ -72,7 +72,7 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Grid</div>
             <div class="col-8">
                 <div class="form-check">
-                    <input type="checkbox" class="form-check-input" id="grid" checked="checked">
+                    <input type="checkbox" class="form-check-input" id="grid" (("checked" if plotting_args["grid"] == true else ""))>
                     <label class="form-check-label col-form-label" for="grid">&nbsp;Display grid</label>
                 </div>
             </div>
@@ -107,13 +107,13 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Label precision</div>
             <div class="col-8 input-group">
                 <span class="col-form-label">Decimal places:&nbsp;</span>
-                <input type="number" id="annotate_precision" class="form-control" min="0" max="10" value="4" step="1">
+                <input type="number" id="annotate_precision" class="form-control" min="0" max="10" value="((plotting_args['annotate_precision']|default(4, true)))" step="1">
             </div>
         </div>
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Label rotation</div>
             <div class="col-8 input-group">
-                <input type="number" id="annotation_rotation" class="form-control" min="0" max="90" value="90" step="1">
+                <input type="number" id="annotation_rotation" class="form-control" min="0" max="90" value="((plotting_args['annotation_rotation']|default(90, true)))" step="1">
                 <div class="input-group-append">
                     <span class="input-group-text">&deg;</span>
                 </div>
@@ -123,16 +123,16 @@ $(document).ready(function() {
             <div class="col-4 col-form-label font-weight-bold text-right">Cosine</div>
             <div class="col-8 input-group">
                 <select class="form-control custom-select" id="cosine">
-                    <option value="standard" selected>Standard</option>
-                    <option value="shifted">Shifted</option>
-                    <option value="off">Off</option>
+                    <option value="standard" (("selected" if plotting_args["cosine"] == "standard"))>Standard</option>
+                    <option value="shifted" (("selected" if plotting_args["cosine"] == "shifted"))>Shifted</option>
+                    <option value="off" (("selected" if plotting_args["cosine"] == false))>Off</option>
                 </select>
             </div>
         </div>
         <div class="form-group row">
             <div class="col-4 col-form-label font-weight-bold text-right">Fragment tolerance</div>
             <div class="col-8 input-group">
-                <input type="number" id="fragment_mz_tolerance" class="form-control" min="0.01" max="1" value="0.02" step="0.01">
+                <input type="number" id="fragment_mz_tolerance" class="form-control" min="0.01" max="1" value="((plotting_args['fragment_mz_tolerance']|default(0.02, true)))" step="0.01">
                 <div class="input-group-append">
                     <span class="input-group-text"><i>m/z</i></span>
                 </div>

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -83,6 +83,12 @@
             {}, "",
             "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
     }
+
+    function resetFigure() {
+        window.location.href = (
+            {}, "",
+            "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
+    }
 </script>
 
 (% endblock %)

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -85,9 +85,7 @@
     }
 
     function resetFigure() {
-        window.location.href = (
-            {}, "",
-            "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))");
+        window.location.href = "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))";
     }
 </script>
 

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -65,9 +65,7 @@
     </div>
 
     <div class="row">
-        <img class="mx-auto"
-             id="render_spectrum"
-             src="/svg/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))"/>
+        <img class="mx-auto" id="render_spectrum" src="data:,"/>
     </div>
 
     (% include 'drawing_controls.html' %)
@@ -81,6 +79,9 @@
         $("#download_svg")[0].href = svg_url + draw_parameters;
         $("#download_png")[0].href = (
             "/png/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
+        window.history.pushState(
+            {}, "",
+            "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
     }
 </script>
 

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -87,7 +87,7 @@
     function resetFigure() {
         window.location.href = (
             {}, "",
-            "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
+            "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))");
     }
 </script>
 

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -79,7 +79,7 @@
         $("#download_svg")[0].href = svg_url + draw_parameters;
         $("#download_png")[0].href = (
             "/png/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
-        window.history.pushState(
+        window.history.replaceState(
             {}, "",
             "/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
     }

--- a/templates/mirror.html
+++ b/templates/mirror.html
@@ -11,41 +11,63 @@
     <div class="row h-100">
         <div class="col-11 my-auto">
             <div class="row">
-                <div class="col-4 font-weight-bold text-right">Universal Spectrum Identifier 1</div>
-                <div class="col-8">((usi1))
+                <div class="col-4 font-weight-bold text-right">
+                    Universal Spectrum Identifier 1
+                </div>
+                <div class="col-8">
+                    (( usi1 ))
                     (% if source_link1 is not none %)
-                        &nbsp;<a href="((source_link1))" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+                        &nbsp;
+                        <a href="(( source_link1 ))" target="_blank">
+                            <i class="fas fa-external-link-alt"></i>
+                        </a>
                     (% endif %)
                 </div>
             </div>
             <div class="row">
-                <div class="col-4 font-weight-bold text-right">Universal Spectrum Identifier 2</div>
-                <div class="col-8">((usi2))
+                <div class="col-4 font-weight-bold text-right">
+                    Universal Spectrum Identifier 2
+                </div>
+                <div class="col-8">
+                    (( usi2 ))
                     (% if source_link2 is not none %)
-                        &nbsp;<a href="((source_link2))" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+                        &nbsp;
+                        <a href="(( source_link2 ))" target="_blank">
+                            <i class="fas fa-external-link-alt"></i>
+                        </a>
                     (% endif %)
                 </div>
             </div>
             <div class="row mt-2">
                 <div class="col-2 offset-4">
-                    <a class="btn btn-primary" id="download_svg" href="/svg/mirror/?usi1=((usi1))&usi2=((usi2))" download="mirror.svg">
+                    <a class="btn btn-primary"
+                       id="download_svg"
+                       href="/svg/mirror/?usi1=(( usi1 ))&usi2=(( usi2 ))"
+                       download="mirror.svg">
                         Download as SVG
                     </a>
                 </div>
                 <div class="col-2">
-                    <a class="btn btn-primary" id="download_png" href="/png/mirror/?usi1=((usi1))&usi2=((usi2))" download="mirror.png">
+                    <a class="btn btn-primary"
+                       id="download_png"
+                       href="/png/mirror/?usi1=(( usi1 ))&usi2=(( usi2 ))"
+                       download="mirror.png">
                         Download as PNG
                     </a>
                 </div>
             </div>
         </div>
         <div class="col-1 my-auto">
-            <img class="mx-auto" src="/qrcode/?mirror=true&usi1=((usi1))&usi2=((usi2))" alt="qr"/>
+            <img class="mx-auto"
+                 src="/qrcode/?mirror=true&usi1=(( usi1 ))&usi2=(( usi2 ))"
+                 alt="qr"/>
         </div>
     </div>
 
     <div class="row">
-        <img class="mx-auto" id="render_spectrum" src="/svg/mirror?usi1=((usi1))&usi2=((usi2))"/>
+        <img class="mx-auto"
+             id="render_spectrum"
+             src="/svg/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))"/>
     </div>
 
     (% include 'drawing_controls.html' %)
@@ -53,11 +75,12 @@
 
 <script type="text/javascript">
     function updateFigure() {
-        let svg_url = "/svg/mirror?usi1=((usi1))&usi2=((usi2))";
+        let svg_url = "/svg/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))";
         let draw_parameters = getDrawingControls();
         $("#render_spectrum")[0].src = svg_url + draw_parameters;
         $("#download_svg")[0].href = svg_url + draw_parameters;
-        $("#download_png")[0].href = "/png/mirror?usi1=((usi1))&usi2=((usi2))" + draw_parameters;
+        $("#download_png")[0].href = (
+            "/png/mirror?usi1=(( usi1 ))&usi2=(( usi2 ))" + draw_parameters);
     }
 </script>
 

--- a/templates/spectrum.html
+++ b/templates/spectrum.html
@@ -61,6 +61,7 @@
         $("#render_spectrum")[0].src = svg_url + draw_parameters;
         $("#download_svg")[0].href = svg_url + draw_parameters;
         $("#download_png")[0].href = "/png/?usi=((usi))" + draw_parameters;
+        window.history.pushState({}, "", "/spectrum/?usi=((usi))" + draw_parameters);
     }
 </script>
 

--- a/templates/spectrum.html
+++ b/templates/spectrum.html
@@ -67,6 +67,7 @@
     </div>
 
     (% include 'drawing_controls.html' %)
+
 </div>
 
 <script type="text/javascript">
@@ -76,8 +77,13 @@
         $("#render_spectrum")[0].src = svg_url + draw_parameters;
         $("#download_svg")[0].href = svg_url + draw_parameters;
         $("#download_png")[0].href = "/png/?usi=(( usi ))" + draw_parameters;
-        window.history.pushState(
+        window.history.replaceState(
             {}, "", "/spectrum/?usi=(( usi ))" + draw_parameters);
+    }
+
+    function resetFigure() {
+        window.location.href = (
+            {}, "", "/spectrum/?usi=(( usi ))");
     }
 </script>
 

--- a/templates/spectrum.html
+++ b/templates/spectrum.html
@@ -82,8 +82,7 @@
     }
 
     function resetFigure() {
-        window.location.href = (
-            {}, "", "/spectrum/?usi=(( usi ))");
+        window.location.href = "/spectrum/?usi=(( usi ))";
     }
 </script>
 

--- a/templates/spectrum.html
+++ b/templates/spectrum.html
@@ -11,44 +11,59 @@
     <div class="row h-100">
         <div class="col-11 my-auto">
             <div class="row">
-                <div class="col-4 font-weight-bold text-right">Universal Spectrum Identifier</div>
+                <div class="col-4 font-weight-bold text-right">
+                    Universal Spectrum Identifier
+                </div>
                 <div class="col-8">
-                    ((usi))
+                    (( usi ))
                     (% if source_link is not none %)
-                        &nbsp;<a href="((source_link))" target="_blank"><i class="fas fa-external-link-alt"></i></a>
+                        &nbsp;
+                        <a href="(( source_link ))" target="_blank">
+                            <i class="fas fa-external-link-alt"></i>
+                        </a>
                     (% endif %)
                 </div>
             </div>
             <div class="row mt-2">
                 <div class="col-2 offset-2">
-                    <a class="btn btn-primary" id="download_json" href="/json/?usi=((usi))">
+                    <a class="btn btn-primary"
+                       id="download_json"
+                       href="/json/?usi=(( usi ))">
                         Download as JSON
                     </a>
                 </div>
                 <div class="col-2">
-                    <a class="btn btn-primary" id="download_csv" href="/csv/?usi=((usi))">
+                    <a class="btn btn-primary"
+                       id="download_csv"
+                       href="/csv/?usi=(( usi ))">
                         Download as CSV
                     </a>
                 </div>
                 <div class="col-2">
-                    <a class="btn btn-primary" id="download_svg" href="/svg/?usi=((usi))" download="((usi)).svg">
+                    <a class="btn btn-primary"
+                       id="download_svg"
+                       href="/svg/?usi=(( usi ))"
+                       download="(( usi )).svg">
                         Download as SVG
                     </a>
                 </div>
                 <div class="col-2">
-                    <a class="btn btn-primary" id="download_png" href="/png/?usi=((usi))" download="((usi)).png">
+                    <a class="btn btn-primary"
+                       id="download_png"
+                       href="/png/?usi=(( usi ))"
+                       download="(( usi )).png">
                         Download as PNG
                     </a>
                 </div>
             </div>
         </div>
         <div class="col-1 my-auto">
-            <img class="mx-auto" src="/qrcode/?usi=((usi))" alt="qr"/>
+            <img class="mx-auto" src="/qrcode/?usi=(( usi ))" alt="qr"/>
         </div>
     </div>
 
     <div class="row">
-        <img class="mx-auto" id="render_spectrum" src="data:," alt="((usi))">
+        <img class="mx-auto" id="render_spectrum" src="data:," alt="(( usi ))">
     </div>
 
     (% include 'drawing_controls.html' %)
@@ -56,12 +71,13 @@
 
 <script type="text/javascript">
     function updateFigure() {
-        let svg_url = "/svg/?usi=((usi))";
+        let svg_url = "/svg/?usi=(( usi ))";
         let draw_parameters = getDrawingControls();
         $("#render_spectrum")[0].src = svg_url + draw_parameters;
         $("#download_svg")[0].href = svg_url + draw_parameters;
-        $("#download_png")[0].href = "/png/?usi=((usi))" + draw_parameters;
-        window.history.pushState({}, "", "/spectrum/?usi=((usi))" + draw_parameters);
+        $("#download_png")[0].href = "/png/?usi=(( usi ))" + draw_parameters;
+        window.history.pushState(
+            {}, "", "/spectrum/?usi=(( usi ))" + draw_parameters);
     }
 </script>
 

--- a/templates/spectrum.html
+++ b/templates/spectrum.html
@@ -48,7 +48,7 @@
     </div>
 
     <div class="row">
-        <img class="mx-auto" id="render_spectrum" src="/svg/?usi=((usi))" alt="((usi))">
+        <img class="mx-auto" id="render_spectrum" src="data:," alt="((usi))">
     </div>
 
     (% include 'drawing_controls.html' %)

--- a/views.py
+++ b/views.py
@@ -95,6 +95,23 @@ def render_mirror_spectrum():
     spectrum2, source2 = parsing.parse_usi(flask.request.args.get('usi2'))
     spectrum2 = copy.deepcopy(spectrum2)
     spectrum2.scale_intensity(max_intensity=1)
+
+    plotting_arguments = _get_plotting_args(flask.request, True)
+
+    spectrum1_peak_annotations = []
+    if plotting_arguments["annotate_peaks"][0] is not True:
+        spectrum1_peak_annotations = _generate_selected_labels(spectrum1, 
+            plotting_arguments["annotate_peaks"][0])
+    else:
+        spectrum1_peak_annotations = _generate_labels(spectrum1)
+
+    spectrum2_peak_annotations = []
+    if plotting_arguments["annotate_peaks"][1] is not True:
+        spectrum2_peak_annotations = _generate_selected_labels(spectrum2, 
+            plotting_arguments["annotate_peaks"][1])
+    else:
+        spectrum2_peak_annotations = _generate_labels(spectrum2)
+
     return flask.render_template(
         'mirror.html',
         usi1=flask.request.args.get('usi1'),
@@ -102,8 +119,8 @@ def render_mirror_spectrum():
         source_link1=source1,
         source_link2=source2,
         peaks=[_get_peaks(spectrum1), _get_peaks(spectrum2)],
-        annotations=[_generate_labels(spectrum1), _generate_labels(spectrum2)],
-        plotting_args=_get_plotting_args(flask.request, True)
+        annotations=[spectrum1_peak_annotations, spectrum2_peak_annotations],
+        plotting_args=plotting_arguments
     )
 
 

--- a/views.py
+++ b/views.py
@@ -71,12 +71,9 @@ def render_spectrum():
         'spectrum.html',
         usi=flask.request.args.get('usi'),
         source_link=source_link,
-        peaks=[
-            _get_peaks(spectrum),
-        ],
-        annotations=[
-            _generate_labels(spectrum),
-        ],
+        peaks=[_get_peaks(spectrum)],
+        annotations=[_generate_labels(spectrum)],
+        plotting_args=_get_plotting_args(flask.request)
     )
 
 
@@ -94,14 +91,9 @@ def render_mirror_spectrum():
         usi2=flask.request.args.get('usi2'),
         source_link1=source1,
         source_link2=source2,
-        peaks=[
-            _get_peaks(spectrum1),
-            _get_peaks(spectrum2),
-        ],
-        annotations=[
-            _generate_labels(spectrum1),
-            _generate_labels(spectrum2),
-        ],
+        peaks=[_get_peaks(spectrum1), _get_peaks(spectrum2)],
+        annotations=[_generate_labels(spectrum1), _generate_labels(spectrum2)],
+        plotting_args=_get_plotting_args(flask.request)
     )
 
 
@@ -117,16 +109,16 @@ def generate_png():
 def generate_mirror_png():
     usi1 = flask.request.args.get('usi1')
     usi2 = flask.request.args.get('usi2')
-    plot_pars = _get_plotting_args(flask.request, mirror=True)
-    buf = _generate_mirror_figure(usi1, usi2, 'png', **plot_pars)
+    plotting_args = _get_plotting_args(flask.request, mirror=True)
+    buf = _generate_mirror_figure(usi1, usi2, 'png', **plotting_args)
     return flask.send_file(buf, mimetype='image/png')
 
 
 @blueprint.route('/svg/')
 def generate_svg():
     usi = flask.request.args.get('usi')
-    plot_pars = _get_plotting_args(flask.request)
-    buf = _generate_figure(usi, 'svg', **plot_pars)
+    plotting_args = _get_plotting_args(flask.request)
+    buf = _generate_figure(usi, 'svg', **plotting_args)
     return flask.send_file(buf, mimetype='image/svg+xml')
 
 
@@ -134,8 +126,8 @@ def generate_svg():
 def generate_mirror_svg():
     usi1 = flask.request.args.get('usi1')
     usi2 = flask.request.args.get('usi2')
-    plot_pars = _get_plotting_args(flask.request, mirror=True)
-    buf = _generate_mirror_figure(usi1, usi2, 'svg', **plot_pars)
+    plotting_args = _get_plotting_args(flask.request, mirror=True)
+    buf = _generate_mirror_figure(usi1, usi2, 'svg', **plotting_args)
     return flask.send_file(buf, mimetype='image/svg+xml')
 
 

--- a/views.py
+++ b/views.py
@@ -24,8 +24,8 @@ requests_cache.install_cache('demo_cache', expire_after=300)
 USI_SERVER = 'https://metabolomics-usi.ucsd.edu/'
 
 default_plotting_args = {
-    'width': 10,
-    'height': 6,
+    'width': 10.0,
+    'height': 6.0,
     'max_intensity_unlabeled': 1.05,
     'max_intensity_labeled': 1.25,
     'max_intensity_mirror_labeled': 1.50,

--- a/views.py
+++ b/views.py
@@ -93,7 +93,7 @@ def render_mirror_spectrum():
         source_link2=source2,
         peaks=[_get_peaks(spectrum1), _get_peaks(spectrum2)],
         annotations=[_generate_labels(spectrum1), _generate_labels(spectrum2)],
-        plotting_args=_get_plotting_args(flask.request)
+        plotting_args=_get_plotting_args(flask.request, True)
     )
 
 


### PR DESCRIPTION
Fixes #110.

Changes in the drawing controls are reflected in the URL and vice versa.

The problem that I haven't been able to fix yet is how to reflect the drawing options in the figure the first time a page loads. I've tried it with `window.onload`, but that's not ideal because the figure is generated twice (default first, updated with customizations second), and it also doesn't play nice with DataTables. Any ideas @mwang87?