### PR TITLE
Fix task annotation parsing

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -102,6 +102,8 @@ def parse_usi(usi: str) -> Tuple[sus.MsmsSpectrum, str, str]:
         collection = match.group(1).lower()
         annotation = match.group(5)
         # Send all proteomics USIs (by definition all annotated USIs) to MassIVE.
+        # mzdraft USIs are assumed to also use ProForma notation.  If this changes,
+        # be sure to change this logic.
         if (annotation is not None or collection.startswith('msv') or collection.startswith('pxd') or
                 collection.startswith('pxl') or collection.startswith('rpxd')
                 or collection == 'massivekb' or collection == 'massive'):
@@ -264,6 +266,7 @@ def _parse_ms2lda(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
 
 # Parse MSV or PXD library.
 def _parse_msv_pxd(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
+    usi = usi.replace('mzdraft','mzspec')
     match = _match_usi(usi)
     dataset_identifier = match.group(1)
     index_flag = match.group(3)

--- a/parsing.py
+++ b/parsing.py
@@ -50,7 +50,7 @@ usi_pattern_draft = re.compile(
     # index flag
     r':(scan|index|nativeId|trace|accession)'
     # index number
-    r':(.+)'
+    r':([^:]+)'
     # optional spectrum interpretation
     r'(:.+)?$',
     flags=re.IGNORECASE
@@ -100,8 +100,9 @@ def parse_usi(usi: str) -> Tuple[sus.MsmsSpectrum, str, str]:
             raise e
     try:
         collection = match.group(1).lower()
-        # Send all proteomics USIs to MassIVE.
-        if (collection.startswith('msv') or collection.startswith('pxd') or
+        annotation = match.group(5)
+        # Send all proteomics USIs (by definition all annotated USIs) to MassIVE.
+        if (annotation is not None or collection.startswith('msv') or collection.startswith('pxd') or
                 collection.startswith('pxl') or collection.startswith('rpxd')
                 or collection == 'massivekb' or collection == 'massive'):
             spectrum, source_link = _parse_msv_pxd(usi)

--- a/parsing.py
+++ b/parsing.py
@@ -266,7 +266,8 @@ def _parse_ms2lda(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
 
 # Parse MSV or PXD library.
 def _parse_msv_pxd(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
-    usi = usi.replace('mzdraft','mzspec')
+    if usi.startswith('mzdraft:'):
+        usi = usi.replace('mzdraft:','mzspec:')
     match = _match_usi(usi)
     dataset_identifier = match.group(1)
     index_flag = match.group(3)

--- a/test/usi_test_data.py
+++ b/test/usi_test_data.py
@@ -24,6 +24,8 @@ usis_to_test = [
     'mzspec:MassIVE:TASK-f4b86b150a164ee4a440b661e97a7193-spectra:scan:309566:AAAPAPVSEAVC[+57.021]R/2',
     'mzspec:PXD002854:20150414_QEp1_LC7_GaPI_SA_Serum_LH_30.mzXML:scan:15073:HPYFYAPELLFFAKR/3',
     'mzspec:MassIVE:TASK-f4b86b150a164ee4a440b661e97a7193-spectra/specs_ms.mgf:scan:287215:HPYFYAPELLF[-10.059]FAKR/3',
+    # MassIVE Task USIs disguised as GNPS Task USIs
+    'mzspec:GNPS:TASK-f4b86b150a164ee4a440b661e97a7193-spectra/specs_ms.mgf:scan:287215:HPYFYAPELLF[-10.059]FAKR/3',
     # Legacy cases.
     'mzspec:GNPSTASK-c95481f0c53d42e78a61bf899e9f9adb:spectra/specs_ms.mgf:scan:1943',
     'mzspec:GNPSTASK-64b22841ab3548f987b3cfc18696a581:spectra/specs_ms.mgf:scan:1469',


### PR DESCRIPTION
1. Fix regex for splitting task identifiers to properly split annotation from scan
2. Prioritize resolution on MassIVE for all USIs with annotations

Fixes https://github.com/mwang87/MetabolomicsSpectrumResolver/issues/158