### PR TITLE
Allow lower case letters in Massbank identifiers.

### DIFF
--- a/metabolomics_spectrum_resolver/parsing.py
+++ b/metabolomics_spectrum_resolver/parsing.py
@@ -416,7 +416,7 @@ def _parse_massbank(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
     index = match.group(4)
     # Clean up the new MassBank accessions if necessary.
     massbank_accession = re.match(
-        r"MSBNK-[A-Z0-9_]{1,32}-([A-Z0-9_]{1,64})", index
+        r"MSBNK-[A-z0-9_]{1,32}-([A-Za-z0-9_]{1,64})", index
     )
     if massbank_accession is not None:
         index = massbank_accession.group(1)

--- a/test/usi_test_data.py
+++ b/test/usi_test_data.py
@@ -10,6 +10,8 @@ usis_to_test = [
     "mzspec:GNPS:GNPS-LIBRARY:accession:CCMSLIB00005436077",
     "mzspec:MASSBANK::accession:SM858102",
     "mzspec:MASSBANK::accession:MSBNK-AAFC-AC000646",
+    # New Massbank identifier with lowercase
+    "mzspec:MASSBANK::accession:MSBNK-Athens_Univ-AU259904",
     "mzspec:MS2LDA:TASK-190:accession:270684",
     "mzspec:MOTIFDB::accession:171163",
     "mzspec:MSV000082791:(-)-epigallocatechin:scan:2",


### PR DESCRIPTION
This fix addresses Fixes #198 in which some full-length Massbank identifiers contain lower case letters and do not match the regex. 

E.g., mzspec:MASSBANK::accession:MSBNK-Athens_Univ-AU259904.