### PR TITLE
Use MassBank documented regex

### DIFF
--- a/metabolomics_spectrum_resolver/parsing.py
+++ b/metabolomics_spectrum_resolver/parsing.py
@@ -416,7 +416,8 @@ def _parse_massbank(usi: str) -> Tuple[sus.MsmsSpectrum, str]:
     index = match.group(4)
     # Clean up the new MassBank accessions if necessary.
     massbank_accession = re.match(
-        r"MSBNK-[A-z0-9_]{1,32}-([A-Za-z0-9_]{1,64})", index
+        # See https://github.com/MassBank/MassBank-web/blob/main/Documentation/MassBankRecordFormat.md#211-accession
+        r"MSBNK-[A-Za-z0–9_]{1,32}-([A-Z0–9_]{1,64})", index
     )
     if massbank_accession is not None:
         index = massbank_accession.group(1)


### PR DESCRIPTION
Hi @mwang87,

Thank you for tagging me in #198 that is now resolved (thanks to #202)!

This PR takes the regex directly from https://github.com/MassBank/MassBank-web/blob/main/Documentation/MassBankRecordFormat.md#211-accession instead (minor).

