### PR TITLE
Update parsing.py

### DIFF
--- a/metabolomics_spectrum_resolver/parsing.py
+++ b/metabolomics_spectrum_resolver/parsing.py
@@ -17,7 +17,7 @@ timeout = 45  # seconds
 MS2LDA_SERVER = "http://ms2lda.org/basicviz/"
 MOTIFDB_SERVER = "http://ms2lda.org/motifdb/"
 MONA_SERVER = "https://massbank.us/rest/spectra/"
-MASSBANKEUROPE_SERVER = "https://msbi.ipb-halle.de/MassBank3-api/v1/records/"
+MASSBANKEUROPE_SERVER = "https://msbi.ipb-halle.de/MassBank-api/v1/records/"
 
 # USI specification: http://www.psidev.info/usi
 usi_pattern = re.compile(


### PR DESCRIPTION
Hi, we want to turn off the preliminary MassBank3-api/ endpopint. This endpoint was only used during development. We deployed our new software now as a replacement for the old software on the our dev server https://msbi.ipb-halle.de/. Its now using MassBank-api/ and MassBank/ as planed for the future. Please adjust the URL you want to use to fetch data from MassBank accordingly.