### PR TITLE
Update MassBankEU API URL

### DIFF
--- a/metabolomics_spectrum_resolver/parsing.py
+++ b/metabolomics_spectrum_resolver/parsing.py
@@ -17,7 +17,7 @@ timeout = 45  # seconds
 MS2LDA_SERVER = "http://ms2lda.org/basicviz/"
 MOTIFDB_SERVER = "http://ms2lda.org/motifdb/"
 MONA_SERVER = "https://massbank.us/rest/spectra/"
-MASSBANKEUROPE_SERVER = "https://msbi.ipb-halle.de/MassBank-api/v1/records/"
+MASSBANKEUROPE_SERVER = "https://msbi.ipb-halle.de/MassBank-api/records/"
 
 # USI specification: http://www.psidev.info/usi
 usi_pattern = re.compile(


### PR DESCRIPTION
The development version of the URL has been deprecated in favor of a permanent URL i.e.,
[https://msbi.ipb-halle.de/MassBank-api/v1/recordsMSBNK-BAFG-CSL2311101855](https://msbi.ipb-halle.de/MassBank-api/v1/recordsMSBNK-BAFG-CSL23111018553) returns a 404
[https://msbi.ipb-halle.de/MassBank-api/records/MSBNK-BAFG-CSL23111018553](https://msbi.ipb-halle.de/MassBank-api/records/MSBNK-BAFG-CSL23111018553) works.
